### PR TITLE
message embed deleted for players votes ranking with file creation

### DIFF
--- a/Commands/utility/TopServer.ts
+++ b/Commands/utility/TopServer.ts
@@ -1,10 +1,10 @@
-import { Message, MessageEmbed, PermissionResolvable } from "discord.js";
+import { Message, PermissionResolvable } from "discord.js";
 import { ICommand } from "../ICommand";
 import { CommandContext } from "../CommandContext";
 import { ServiceProvider } from "../../src/ServiceProvider";
 import { Player } from "../../Models/TopServerModel";
-import { Config } from "../../Config/Config";
 import { TopServerService } from "../../Services/TopServerService";
+import * as fs from "fs";
 
 export class TopServerCommand implements ICommand {
 	public readonly name: string = "topserveur";
@@ -35,27 +35,11 @@ export class TopServerCommand implements ICommand {
 			title = "Classement Top Serveur du mois en cours";
 		}
 
-		const messageEmbed = new MessageEmbed()
-			.attachFiles(["./Images/topServeur.png"])
-			.setThumbnail("attachment://topServeur.png")
-			.setTitle(title)
-			.setColor(Config.color)
-			.setTimestamp();
-
-		players.map(p => {
-			if (p.name === "") {
-				messageEmbed.addField("Sans pseudo", `${p.votes.toString()}`, false);
-			}
-			else {
-				messageEmbed.addField(`${p.name}`, `${p.votes.toString()}`, false);
-			}
+		const fileName: string = topServerService.fileName;
+		await topServerService.createRankingFile(players);
+		await message.author.send(title, { files: [fileName] });
+		fs.rm(fileName, err => {
+			if (err) console.error(err);
 		});
-
-		if (messageEmbed.length > 6000) {
-			await message.author.send("Le résulat est trop volumineux pour être affiché");
-		}
-		else {
-			await message.author.send(messageEmbed);
-		}
 	}
 }

--- a/Services/TopServerService.ts
+++ b/Services/TopServerService.ts
@@ -1,9 +1,12 @@
 import { TopServerRepository } from "../Dal/TopServerRepository";
 import { Player, TopServerModel } from "../Models/TopServerModel";
 import { AutoMapper } from "./AutoMapper";
+import * as fs from "fs";
+import { appendFileSync, WriteStream } from "fs";
 
 export class TopServerService {
 	private _topServerRepository: TopServerRepository;
+	public readonly fileName: string = "topserveur.txt";
 
 	constructor() {
 		this._topServerRepository = new TopServerRepository();
@@ -30,11 +33,24 @@ export class TopServerService {
 	 * Retourne le total des votes pour le mois courant
 	 * @constructor
 	 */
-	public async GetNumberOfVotes(): Promise<number> {
+	public async getNumberOfVotes(): Promise<number> {
 		const stats: any = await this._topServerRepository.getServerStats();
 		const date: number = new Date().getMonth();
 		const months: string[] = ["january", "february", "march", "april", "may", "june", "july", "august", "september", "october", "november", "december" ];
 		const currentMonth: string = months[date];
 		return stats.monthly[0][currentMonth + "_votes"];
+	}
+
+	/**
+	 * Créer un fichier avec le classement des votes
+	 * @param players {Player[]}
+	 */
+	public async createRankingFile(players: Player[]) {
+		let number: number = 1;
+		players.map(async player => {
+			if (player.name === "") player.name = "Sans pseudo";
+			fs.appendFileSync(this.fileName, `${number.toString()} - ${player.name} - ${player.votes} votes \n`);
+			number++;
+		})
 	}
 }

--- a/Services/VoteService.ts
+++ b/Services/VoteService.ts
@@ -1,4 +1,4 @@
-import { Message, MessageEmbed, TextChannel, WebhookClient } from "discord.js";
+import { Message, MessageEmbed, TextChannel } from "discord.js";
 import { Config } from "../Config/Config";
 import { VoteRepository } from "../Dal/VoteRepository";
 import { TopServerModel } from "../Models/TopServerModel";
@@ -60,7 +60,7 @@ export class VoteService {
 	 */
 	public async sendMessage(): Promise<void> {
 		const topServerModel: TopServerModel = await this._topServerService.getSlugTopServer();
-		const numberOfVotes: number = await this._topServerService.GetNumberOfVotes();
+		const numberOfVotes: number = await this._topServerService.getNumberOfVotes();
 		const topServeurUrl: string = "https://top-serveurs.net/conan-exiles/vote/" + topServerModel.slug;
 
 		const messageEmbed = new MessageEmbed()

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "bot-discord-bannis-ts",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
         "axios": "^0.21.1",


### PR DESCRIPTION
Modification de la fonctionnalité chargé de l'envoi du classement des votes sur Top Serveur 👍 

- Les résultats envoyés sont incomplets
- Les `message embed` sont limités avec 25 `field` max

Désormais, les résultats sont envoyés dans un fichier `txt`